### PR TITLE
Build with clang-7 (when building with clang)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
     apt:
         sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-trusty-7
         packages:
             - g++-7
-            - clang-tidy-5.0
+            - clang-tidy-7
             - libnss3-dev


### PR DESCRIPTION
Allows getting rid of searching for errors in the tidy log