### PR TITLE
extern: extract version/hash info for the projects

### DIFF
--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set(GOOGLETEST_VERSION 1.8.1)
+set(GOOGLETEST_SHA256SUM 9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c)
+
 if (NOT ODFSIG_INTERNAL_LIBGTEST)
     find_package(GTest REQUIRED)
 else ()
@@ -9,8 +12,8 @@ else ()
     include(GNUInstallDirs)
     find_package(Threads REQUIRED)
     ExternalProject_Add(extern-googletest-project
-        URL https://github.com/google/googletest/archive/release-1.8.1.tar.gz
-        URL_HASH SHA256=9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c
+        URL https://github.com/google/googletest/archive/release-${GOOGLETEST_VERSION}.tar.gz
+        URL_HASH SHA256=${GOOGLETEST_SHA256SUM}
         PATCH_COMMAND ${PATCH_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/msvc-debug.patch
         DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/extern/tarballs

--- a/extern/libxml2/CMakeLists.txt
+++ b/extern/libxml2/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set(LIBXML2_VERSION 2.9.8)
+set(LIBXML2_SHA256SUM 0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732)
+
 if (ODFSIG_INTERNAL_LIBXML2)
     include(ExternalProject)
     include(GNUInstallDirs)
@@ -32,8 +35,8 @@ if (ODFSIG_INTERNAL_LIBXML2)
             ${CMAKE_CURRENT_BINARY_DIR}/install/${CMAKE_INSTALL_LIBDIR}/libxml2.a)
     endif()
     ExternalProject_Add(extern-libxml2-project
-        URL http://xmlsoft.org/sources/libxml2-2.9.8.tar.gz
-        URL_HASH SHA256=0b74e51595654f958148759cfef0993114ddccccbb6f31aee018f3558e8e2732
+        URL http://xmlsoft.org/sources/libxml2-${LIBXML2_VERSION}.tar.gz
+        URL_HASH SHA256=${LIBXML2_SHA256SUM}
         DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/extern/tarballs
         BUILD_IN_SOURCE ON
         CONFIGURE_COMMAND ${CONFIGURE_COMMAND}

--- a/extern/libzip/CMakeLists.txt
+++ b/extern/libzip/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set(LIBZIP_VERSION 1.5.1)
+set(LIBZIP_SHA256SUM 47eaa45faa448c72bd6906e5a096846c469a185f293cafd8456abb165841b3f2)
+
 if (WIN32)
     set(ZLIB_ROOT_OPTION -DZLIB_ROOT=${CMAKE_CURRENT_BINARY_DIR}/../zlib/install)
     set(LIBZIP_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/install/lib/zip.lib)
@@ -23,8 +26,8 @@ else ()
         set(ZLIB_LIBRARIES zlib)
     endif()
     ExternalProject_Add(extern-libzip-project
-        URL https://libzip.org/download/libzip-1.5.1.tar.gz
-        URL_HASH SHA256=47eaa45faa448c72bd6906e5a096846c469a185f293cafd8456abb165841b3f2
+        URL https://libzip.org/download/libzip-${LIBZIP_VERSION}.tar.gz
+        URL_HASH SHA256=${LIBZIP_SHA256SUM}
         PATCH_COMMAND ${PATCH_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/add-an-option-to-disable-bzip2-support.patch
         DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/extern/tarballs

--- a/extern/xmlsec/CMakeLists.txt
+++ b/extern/xmlsec/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set(XMLSEC_VERSION 1.2.26)
+set(XMLSEC_SHA256SUM 8d8276c9c720ca42a3b0023df8b7ae41a2d6c5f9aa8d20ed1672d84cc8982d50)
+
 if (NOT ODFSIG_INTERNAL_XMLSEC)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(XMLSEC REQUIRED xmlsec1-nss)
@@ -61,8 +64,8 @@ else ()
     endif ()
 
     ExternalProject_Add(extern-xmlsec-project
-        URL http://www.aleksey.com/xmlsec/download/xmlsec1-1.2.26.tar.gz
-        URL_HASH SHA256=8d8276c9c720ca42a3b0023df8b7ae41a2d6c5f9aa8d20ed1672d84cc8982d50
+        URL http://www.aleksey.com/xmlsec/download/xmlsec1-${XMLSEC_VERSION}.tar.gz
+        URL_HASH SHA256=${XMLSEC_SHA256SUM}
         PATCH_COMMAND ${PATCH_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/mscng-fixes.patch
             ${CMAKE_CURRENT_SOURCE_DIR}/nss-fix-memory-leak-in-GetCertName-220.patch

--- a/extern/zlib/CMakeLists.txt
+++ b/extern/zlib/CMakeLists.txt
@@ -2,12 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+set(ZLIB_VERSION 1.2.11)
+set(ZLIB_SHA256SUM c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1)
+
 if (ODFSIG_INTERNAL_ZLIB)
     include(ExternalProject)
 
     ExternalProject_Add(extern-zlib-project
-        URL http://zlib.net/zlib-1.2.11.tar.gz
-        URL_HASH SHA256=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+        URL http://zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+        URL_HASH SHA256=${ZLIB_SHA256SUM}
         # Proposed upstream at <https://github.com/madler/zlib/pull/385>.
         PATCH_COMMAND ${PATCH_EXECUTABLE}
             ${CMAKE_CURRENT_SOURCE_DIR}/msvc-debug.patch


### PR DESCRIPTION
So that later it'll be possible to automatically check which ones are
outdated.