### PR TITLE
Don't silently ignore unrecognized arguments

### DIFF
--- a/docs/odfsig.adoc
+++ b/docs/odfsig.adoc
@@ -30,6 +30,11 @@ following locations:
 --trusted-der <file>::
 	Load trusted (root) certificate (chain) from a DER file.
 
+== EXIT STATUS
+
+The exit status is 0 if all signatures are valid, 1 if at least one signature
+is invalid, and 2 if an error occurred.
+
 == LICENSE
 
 Use of this source code is governed by a BSD-style license that can be found in

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <odfsig/lib.hxx>
+#include <odfsig/string.hxx>
 #include <odfsig/version.hxx>
 
 namespace
@@ -125,7 +126,8 @@ class Options
 };
 
 /// Minimal option parser to avoid Boost.Program_options dependency.
-void parseOptions(std::vector<const char*>& args, Options& options)
+bool parseOptions(std::vector<const char*>& args, Options& options,
+                  std::ostream& ostream)
 {
     bool inTrustedDer = false;
     for (const auto& arg : args)
@@ -144,9 +146,17 @@ void parseOptions(std::vector<const char*>& args, Options& options)
             options.setHelp(true);
         else if (argString == "--version")
             options.setVersion(true);
+        else if (odfsig::starts_with(argString, "--"))
+        {
+            ostream << "Error: unrecognized argument: " << argString
+                    << std::endl;
+            return false;
+        }
         else
             options.setOdfPath(argString);
     }
+
+    return true;
 }
 
 void usage(const std::string& self, std::ostream& ostream)
@@ -177,7 +187,8 @@ int main(int argc, const char* argv[], std::ostream& ostream)
 
     std::vector<const char*> args(argv, argv + argc);
     Options options;
-    parseOptions(args, options);
+    if (!parseOptions(args, options, ostream))
+        return 2;
     if (options.isHelp())
     {
         usage(argv[0], ostream);

--- a/tests/testlib.cxx
+++ b/tests/testlib.cxx
@@ -175,4 +175,15 @@ TEST(OdfsigTest, testCmdlineNoArgs)
     ASSERT_EQ(1, odfsig::main(args.size(), args.data(), ss));
 }
 
+TEST(OdfsigTest, testCmdlineBadArg)
+{
+    // Bad argument.
+    std::vector<const char*> args{"odfsig", "--trusted-derr",
+                                  "tests/keys/ca-chain.cert.der",
+                                  "tests/data/good.odt"};
+    std::stringstream ss;
+    // This was 1, bad argument was just ignored silently.
+    ASSERT_EQ(2, odfsig::main(args.size(), args.data(), ss));
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Exit code modeled after grep(1).