### PR TITLE
Travis: still build release tags as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,5 +58,6 @@ deploy:
     - "$TRAVIS_DEPLOY == y"
     tags: true
 branches:
-  only:
-    - master
+  except:
+    # build e.g. master, but not for/master
+    - /for\/.*/


### PR DESCRIPTION
The intention was to skip for/*, I forgot that tag builds are how
binaries are produced.

Change-Id: Iabcc22f5e0e54c78825b676ac9f918faf2517231
