### PR TITLE
getCertificateSubjectName: use size_t to represent length

### DIFF
--- a/include/odfsig/crypto.hxx
+++ b/include/odfsig/crypto.hxx
@@ -38,7 +38,7 @@ class Crypto
 
     /// Extracts the subject name of an X509 certificate.
     virtual std::string getCertificateSubjectName(unsigned char* certificate,
-                                                  int size) = 0;
+                                                  size_t size) = 0;
 
     static std::unique_ptr<Crypto> create();
 };

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -6,6 +6,7 @@
 # Baseline: Ubuntu 18.04 and macOS 10.15.
 
 if [ -n "${GITHUB_JOB}" -a "$(uname -s)" == "Linux" ]; then
+    sudo apt-get update
     sudo apt-get install \
         clang-tidy \
         gyp \

--- a/src/crypto-cng.cxx
+++ b/src/crypto-cng.cxx
@@ -47,7 +47,7 @@ class CngCrypto : public Crypto
                                std::vector<std::string> trustedDers) override;
 
     std::string getCertificateSubjectName(unsigned char* certificate,
-                                          int size) override;
+                                          size_t size) override;
 };
 
 bool CngCrypto::initialize(const std::string& cryptoConfig)
@@ -83,7 +83,7 @@ bool CngCrypto::initializeKeysManager(xmlSecKeysMngr* keysManager,
 }
 
 std::string CngCrypto::getCertificateSubjectName(unsigned char* certificate,
-                                                 int size)
+                                                 size_t size)
 {
     std::unique_ptr<const CERT_CONTEXT> context(
         CertCreateCertificateContext(X509_ASN_ENCODING, certificate, size));

--- a/src/crypto-nss.cxx
+++ b/src/crypto-nss.cxx
@@ -94,7 +94,7 @@ class NssCrypto : public Crypto
                                std::vector<std::string> trustedDers) override;
 
     std::string getCertificateSubjectName(unsigned char* certificate,
-                                          int size) override;
+                                          size_t size) override;
 };
 
 bool NssCrypto::initialize(const std::string& cryptoConfig)
@@ -135,7 +135,7 @@ bool NssCrypto::initializeKeysManager(xmlSecKeysMngr* keysManager,
 }
 
 std::string NssCrypto::getCertificateSubjectName(unsigned char* certificate,
-                                                 int size)
+                                                 size_t size)
 {
     SECItem certItem;
     certItem.data = certificate;

--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -142,7 +142,7 @@ int read(void* context, char* buffer, int len)
     auto* zipFile = static_cast<zip::File*>(context);
     assert(zipFile);
 
-    return zipFile->read(buffer, len);
+    return static_cast<int>(zipFile->read(buffer, len));
 }
 
 int close(void* context)


### PR DESCRIPTION
To avoid a bugprone narrowing conversion.

Change-Id: I3b5fafe9c10ed2cd6b9500bd809f25b8ae039735
