### PR TITLE
Avoid repeating the return type from the declaration

### DIFF
--- a/src/crypto-nss.cxx
+++ b/src/crypto-nss.cxx
@@ -53,7 +53,7 @@ std::string getFirefoxProfile(const std::string& cryptoConfig)
     std::ifstream profilesIni(firefoxPath + "profiles.ini");
     if (!profilesIni.good())
     {
-        return std::string();
+        return {};
     }
 
     std::string profilePath;
@@ -72,7 +72,7 @@ std::string getFirefoxProfile(const std::string& cryptoConfig)
         }
     }
 
-    return std::string();
+    return {};
 }
 } // namespace
 
@@ -145,10 +145,10 @@ std::string NssCrypto::getCertificateSubjectName(unsigned char* certificate,
         CERT_GetDefaultCertDB(), &certItem, nullptr, PR_FALSE, PR_TRUE));
     if (!cert || (cert->subjectName == nullptr))
     {
-        return std::string();
+        return {};
     }
 
-    return std::string(cert->subjectName);
+    return cert->subjectName;
 }
 
 std::unique_ptr<Crypto> Crypto::create()

--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -522,7 +522,7 @@ std::string XmlSignature::getSubjectName() const
     std::vector<xmlChar> certificate;
     if (!getCertificateBinary(certificate))
     {
-        return std::string();
+        return {};
     }
 
     return _crypto.getCertificateSubjectName(certificate.data(),
@@ -537,14 +537,14 @@ std::string XmlSignature::getMethod() const
         signedInfoNode, xmlSecNodeSignatureMethod, xmlSecDSigNs);
     if (signatureMethodNode == nullptr)
     {
-        return std::string();
+        return {};
     }
 
     std::unique_ptr<xmlChar> href(
         xmlGetProp(signatureMethodNode, xmlSecAttrAlgorithm));
     if (!href)
     {
-        return std::string();
+        return {};
     }
 
     xmlSecTransformId id =
@@ -555,7 +555,7 @@ std::string XmlSignature::getMethod() const
         return fromXmlChar(href.get());
     }
 
-    return std::string(fromXmlChar(xmlSecTransformKlassGetName(id)));
+    return fromXmlChar(xmlSecTransformKlassGetName(id));
 }
 
 std::set<std::string> XmlSignature::getSignedStreams() const
@@ -600,10 +600,10 @@ std::string XmlSignature::getType() const
 {
     if (getCertDigestNode() != nullptr)
     {
-        return std::string("XAdES");
+        return "XAdES";
     }
 
-    return std::string("XML-DSig");
+    return "XML-DSig";
 }
 
 xmlNodePtr XmlSignature::getObjectCertDigestNode(xmlNode* objectNode)
@@ -673,7 +673,7 @@ std::string XmlSignature::getDate() const
         }
     }
 
-    return std::string();
+    return {};
 }
 
 std::string XmlSignature::getObjectDate(xmlNode* objectNode)
@@ -694,7 +694,7 @@ std::string XmlSignature::getObjectDate(xmlNode* objectNode)
         }
     }
 
-    return std::string();
+    return {};
 }
 
 std::string XmlSignature::getDateContent(xmlNode* dateNode)
@@ -702,10 +702,10 @@ std::string XmlSignature::getDateContent(xmlNode* dateNode)
     std::unique_ptr<xmlChar> content(xmlNodeGetContent(dateNode));
     if (!content)
     {
-        return std::string();
+        return {};
     }
 
-    return std::string(fromXmlChar(content.get()));
+    return fromXmlChar(content.get());
 }
 
 std::string
@@ -730,7 +730,7 @@ XmlSignature::getSignaturePropertiesDate(xmlNode* signaturePropertiesNode)
         }
     }
 
-    return std::string();
+    return {};
 }
 
 std::string
@@ -740,7 +740,7 @@ XmlSignature::getSignaturePropertyDate(xmlNode* signaturePropertyNode)
         xmlSecFindChild(signaturePropertyNode, dateNodeName, dateNsName);
     if (dateNode == nullptr)
     {
-        return std::string();
+        return {};
     }
 
     return getDateContent(dateNode);

--- a/src/zip.cxx
+++ b/src/zip.cxx
@@ -157,7 +157,7 @@ std::string ZipArchive::getName(int64_t index)
     const char* name = zip_get_name(_archive, index, 0);
     if (name == nullptr)
     {
-        return std::string();
+        return {};
     }
 
     return name;


### PR DESCRIPTION
Use a braced initializer list instead.

Change-Id: I9af0bae1eb3860a9c0424fc690be03e9a1594dcf
