### PR TITLE
Avoid too short variable names

### DIFF
--- a/include/odfsig/string.hxx
+++ b/include/odfsig/string.hxx
@@ -12,9 +12,9 @@ namespace odfsig
 /// Checks if `big` begins with `prefix`.
 bool starts_with(const std::string& big, const std::string& prefix);
 
-/// Replaces `from` with `to` in `str`.
+/// Replaces `from` with `replacement` in `str`.
 void replace_all(std::string& str, const std::string& from,
-                 const std::string& to);
+                 const std::string& replacement);
 } // namespace odfsig
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/src/crypto-nss.cxx
+++ b/src/crypto-nss.cxx
@@ -46,10 +46,10 @@ namespace
  */
 std::string getFirefoxProfile(const std::string& cryptoConfig)
 {
-    std::stringstream ss;
-    ss << cryptoConfig;
-    ss << "/.mozilla/firefox/";
-    const std::string firefoxPath = ss.str();
+    std::stringstream stream;
+    stream << cryptoConfig;
+    stream << "/.mozilla/firefox/";
+    const std::string firefoxPath = stream.str();
 
     std::ifstream profilesIni(firefoxPath + "profiles.ini");
     if (!profilesIni.good())

--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -77,9 +77,9 @@ bool ends_with(const std::string& big, const std::string& suffix)
 }
 
 /// Converts from libxml char to normal char.
-const char* fromXmlChar(const xmlChar* s)
+const char* fromXmlChar(const xmlChar* string)
 {
-    return reinterpret_cast<const char*>(s);
+    return reinterpret_cast<const char*>(string);
 }
 } // namespace
 
@@ -261,7 +261,7 @@ class XmlSignature : public Signature
 
     static std::unique_ptr<xmlChar> getDigestAlgo(xmlNodePtr certDigest);
 
-    static bool hash(const std::vector<xmlChar>& in,
+    static bool hash(const std::vector<xmlChar>& input,
                      std::unique_ptr<xmlChar> algo,
                      std::vector<unsigned char>& out);
 
@@ -430,7 +430,7 @@ std::unique_ptr<xmlChar> XmlSignature::getDigestAlgo(xmlNodePtr certDigest)
     return algo;
 }
 
-bool XmlSignature::hash(const std::vector<xmlChar>& in,
+bool XmlSignature::hash(const std::vector<xmlChar>& input,
                         std::unique_ptr<xmlChar> algo,
                         std::vector<unsigned char>& out)
 {
@@ -455,8 +455,8 @@ bool XmlSignature::hash(const std::vector<xmlChar>& in,
     }
 
     hash->operation = xmlSecTransformOperationSign;
-    if (xmlSecTransformCtxBinaryExecute(transform.get(), in.data(), in.size()) <
-        0)
+    if (xmlSecTransformCtxBinaryExecute(transform.get(), input.data(),
+                                        input.size()) < 0)
     {
         return false;
     }
@@ -547,15 +547,15 @@ std::string XmlSignature::getMethod() const
         return {};
     }
 
-    xmlSecTransformId id =
+    xmlSecTransformId transformId =
         xmlSecTransformIdListFindByHref(xmlSecTransformIdsGet(), href.get(),
                                         xmlSecTransformUsageSignatureMethod);
-    if (id == xmlSecTransformIdUnknown)
+    if (transformId == xmlSecTransformIdUnknown)
     {
         return fromXmlChar(href.get());
     }
 
-    return fromXmlChar(xmlSecTransformKlassGetName(id));
+    return fromXmlChar(xmlSecTransformKlassGetName(transformId));
 }
 
 std::set<std::string> XmlSignature::getSignedStreams() const
@@ -890,10 +890,10 @@ bool ZipVerifier::parseSignatures()
     _zipFile = zip::File::create(_zipArchive.get(), _signaturesZipIndex);
     if (!_zipFile)
     {
-        std::stringstream ss;
-        ss << "Can't open file at index " << _signaturesZipIndex << ":"
-           << _zipArchive->getErrorString();
-        _errorString = ss.str();
+        std::stringstream stream;
+        stream << "Can't open file at index " << _signaturesZipIndex << ":"
+               << _zipArchive->getErrorString();
+        _errorString = stream.str();
         return false;
     }
 
@@ -908,10 +908,10 @@ bool ZipVerifier::parseSignatures()
     }
     if (readSize == -1)
     {
-        std::stringstream ss;
-        ss << "Can't read file at index " << _signaturesZipIndex << ": "
-           << _zipFile->getErrorString();
-        _errorString = ss.str();
+        std::stringstream stream;
+        stream << "Can't read file at index " << _signaturesZipIndex << ": "
+               << _zipFile->getErrorString();
+        _errorString = stream.str();
         return false;
     }
 

--- a/src/string.cxx
+++ b/src/string.cxx
@@ -16,7 +16,7 @@ bool starts_with(const std::string& big, const std::string& prefix)
 }
 
 void replace_all(std::string& str, const std::string& from,
-                 const std::string& to)
+                 const std::string& replacement)
 {
     size_t index = 0;
 
@@ -28,9 +28,9 @@ void replace_all(std::string& str, const std::string& from,
             break;
         }
 
-        str.replace(index, from.size(), to);
+        str.replace(index, from.size(), replacement);
 
-        index += to.size();
+        index += replacement.size();
     }
 }
 } // namespace odfsig

--- a/tests/testlib.cxx
+++ b/tests/testlib.cxx
@@ -113,8 +113,8 @@ TEST(OdfsigTest, testTrustedDerCmdline)
     std::vector<const char*> args{"odfsig", "--trusted-der",
                                   "tests/keys/ca-chain.cert.der",
                                   "tests/data/good.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(0, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(0, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testInsecureCmdline)
@@ -122,32 +122,32 @@ TEST(OdfsigTest, testInsecureCmdline)
     // --insecure results in working validation.
     std::vector<const char*> args{"odfsig", "--insecure",
                                   "tests/data/good.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(0, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(0, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineHelp)
 {
     // --help resulted in an error.
     std::vector<const char*> args{"odfsig", "--help"};
-    std::stringstream ss;
-    ASSERT_EQ(0, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(0, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineVersion)
 {
     // --version resulted in an error.
     std::vector<const char*> args{"odfsig", "--version"};
-    std::stringstream ss;
-    ASSERT_EQ(0, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(0, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineNoStream)
 {
     // No signatures stream.
     std::vector<const char*> args{"odfsig", "tests/data/no-stream.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineBad)
@@ -156,8 +156,8 @@ TEST(OdfsigTest, testCmdlineBad)
     std::vector<const char*> args{"odfsig", "--trusted-der",
                                   "tests/keys/ca-chain.cert.der",
                                   "tests/data/bad.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineBadMulti)
@@ -166,25 +166,25 @@ TEST(OdfsigTest, testCmdlineBadMulti)
     std::vector<const char*> args{"odfsig", "--trusted-der",
                                   "tests/keys/ca-chain.cert.der",
                                   "tests/data/bad.odt", "tests/data/good.odt"};
-    std::stringstream ss;
+    std::stringstream stream;
     // This failed, only the last file was verified.
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineBadPath)
 {
     // Non-existing path.
     std::vector<const char*> args{"odfsig", "tests/data/asdf.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineNoArgs)
 {
     // No arguments.
     std::vector<const char*> args{"odfsig"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineBadArg)
@@ -193,25 +193,25 @@ TEST(OdfsigTest, testCmdlineBadArg)
     std::vector<const char*> args{"odfsig", "--trusted-derr",
                                   "tests/keys/ca-chain.cert.der",
                                   "tests/data/good.odt"};
-    std::stringstream ss;
+    std::stringstream stream;
     // This was 1, bad argument was just ignored silently.
-    ASSERT_EQ(2, odfsig::main(args, ss));
+    ASSERT_EQ(2, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineDirArg)
 {
     // Directory argument.
     std::vector<const char*> args{"odfsig", "tests/data/"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 TEST(OdfsigTest, testCmdlineNonZip)
 {
     // Input is not a ZIP file: this used to crash.
     std::vector<const char*> args{"odfsig", "tests/data/non-zip.odt"};
-    std::stringstream ss;
-    ASSERT_EQ(1, odfsig::main(args, ss));
+    std::stringstream stream;
+    ASSERT_EQ(1, odfsig::main(args, stream));
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Change-Id: Ie867eab6c07442ed192d19e69f8d05481c3091b5
