### PR TITLE
Fix zlib homepage

### DIFF
--- a/scripts/extern.py
+++ b/scripts/extern.py
@@ -17,7 +17,7 @@ releaseMonitoring = {
     "libxml2": ["libxml2", "http://xmlsoft.org/"],
     "libzip": ["libzip", "https://libzip.org/"],
     "xmlsec": ["xmlsec1", "http://www.aleksey.com/xmlsec/download.html"],
-    "zlib": ["zlib", "https://www.zlib.net/"],
+    "zlib": ["zlib", "https://www.zlib.net"],
     "nss": ["nss", "https://ftp.mozilla.org/pub/security/nss/releases/"],
 }
 


### PR DESCRIPTION
checking for zlib-1.2.13...WARNING: 'https://release-monitoring.org/api/v2/projects/?name=zlib' contains no homepage 'https://www.zlib.net/'

Change-Id: Idbe12af1b9d9f986a2455c06ce6ade56411a0563
