### PR TITLE
Update xmlsec to 1.2.37

### DIFF
--- a/extern/xmlsec/CMakeLists.txt
+++ b/extern/xmlsec/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-set(XMLSEC_VERSION 1.2.34)
-set(XMLSEC_SHA256SUM 52ced4943f35bd7d0818a38298c1528ca4ac8a54440fd71134a07d2d1370a262)
+set(XMLSEC_VERSION 1.2.37)
+set(XMLSEC_SHA256SUM 5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c)
 
 if (NOT ODFSIG_INTERNAL_XMLSEC)
     find_package(PkgConfig REQUIRED)

--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -349,10 +349,10 @@ bool XmlSignature::getCertificateBinary(std::vector<xmlChar>& certificate) const
     }
 
     // Decode the certificate in-place.
-    int certSize = xmlSecBase64Decode(certificateContent.get(),
-                                      (xmlSecByte*)certificateContent.get(),
-                                      xmlStrlen(certificateContent.get()));
-    if (certSize < 0)
+    xmlSecSize certSize;
+    if (xmlSecBase64Decode_ex(
+            certificateContent.get(), (xmlSecByte*)certificateContent.get(),
+            xmlStrlen(certificateContent.get()), &certSize) < 0)
     {
         return false;
     }
@@ -403,10 +403,11 @@ bool XmlSignature::getDigestValue(xmlNodePtr certDigest,
     }
 
     // Decode the expected hash in-place.
-    int expectedDigestSize = xmlSecBase64Decode(
-        digestValueNodeContent.get(), (xmlSecByte*)digestValueNodeContent.get(),
-        xmlStrlen(digestValueNodeContent.get()));
-    if (expectedDigestSize < 0)
+    xmlSecSize expectedDigestSize;
+    if (xmlSecBase64Decode_ex(digestValueNodeContent.get(),
+                              (xmlSecByte*)digestValueNodeContent.get(),
+                              xmlStrlen(digestValueNodeContent.get()),
+                              &expectedDigestSize) < 0)
     {
         return false;
     }


### PR DESCRIPTION
Deprecates xmlSecBase64Decode().

Change-Id: Ia6aa8d1c79eea2268073ab1ee675bd47cd798f3c
