### PR TITLE
libzip: disable dev warnings

### DIFF
--- a/extern/libzip/CMakeLists.txt
+++ b/extern/libzip/CMakeLists.txt
@@ -21,6 +21,7 @@ else ()
         URL_HASH SHA256=${LIBZIP_SHA256SUM}
         DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/extern/tarballs
         CONFIGURE_COMMAND ${CMAKE_COMMAND}
+            -Wno-dev
             -DBUILD_SHARED_LIBS=OFF
             -DENABLE_GNUTLS=OFF
             -DENABLE_OPENSSL=OFF


### PR DESCRIPTION
They are not relevant for libzip users like us.

Change-Id: Ic51e9d7df3e7a18d79ccbb4f098ba7175067512a
