### PR TITLE
Switch to SPDX-style license identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20.4)
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 # odfsig cmdline app.
 add_executable(odfsig

--- a/apps/app.cxx
+++ b/apps/app.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <iostream>

--- a/apps/fuzz.cxx
+++ b/apps/fuzz.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <libxml/xmlerror.h>

--- a/cmake/HandleAsciidoc.cmake
+++ b/cmake/HandleAsciidoc.cmake
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 find_program(A2X
     a2x

--- a/cmake/HandleOdfsigOptions.cmake
+++ b/cmake/HandleOdfsigOptions.cmake
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 if (ODFSIG_ENABLE_CCACHE)
     find_program(CCACHE_PROGRAM ccache)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 if (A2X)
     include(GNUInstallDirs)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 # 'git apply' is more cross-platform than 'patch -p1 -i'.
 set(PATCH_EXECUTABLE git --work-tree=. --git-dir=.git apply --ignore-whitespace --whitespace=nowarn --verbose)

--- a/extern/googletest/CMakeLists.txt
+++ b/extern/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(GOOGLETEST_VERSION 1.13.0)
 set(GOOGLETEST_SHA256SUM ad7fdba11ea011c1d925b3289cf4af2c66a352e18d4c7264392fead75e919363)

--- a/extern/libxml2/CMakeLists.txt
+++ b/extern/libxml2/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(LIBXML2_VERSION 2.10.3)
 set(LIBXML2_SHA256SUM 5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c)

--- a/extern/libzip/CMakeLists.txt
+++ b/extern/libzip/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2019 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2019 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(LIBZIP_VERSION 1.9.2)
 set(LIBZIP_SHA256SUM fd6a7f745de3d69cf5603edc9cb33d2890f0198e415255d0987a0cf10d824c6f)

--- a/extern/nss/CMakeLists.txt
+++ b/extern/nss/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(NSS_VERSION 3.89)
 set(NSS_SHA256SUM e40012df101331eadb87cfdb204969ab2a4b9a81735deba94fe5501aff12fd65)

--- a/extern/xmlsec/CMakeLists.txt
+++ b/extern/xmlsec/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(XMLSEC_VERSION 1.2.37)
 set(XMLSEC_SHA256SUM 5f8dfbcb6d1e56bddd0b5ec2e00a3d0ca5342a9f57c24dffde5c796b2be2871c)

--- a/extern/zlib/CMakeLists.txt
+++ b/extern/zlib/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 set(ZLIB_VERSION 1.2.13)
 set(ZLIB_SHA256SUM b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 include(FindGit)
 

--- a/include/odfsig/crypto.hxx
+++ b/include/odfsig/crypto.hxx
@@ -1,8 +1,8 @@
 #pragma once
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <memory>

--- a/include/odfsig/lib.hxx
+++ b/include/odfsig/lib.hxx
@@ -1,8 +1,8 @@
 #pragma once
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <memory>

--- a/include/odfsig/string.hxx
+++ b/include/odfsig/string.hxx
@@ -1,8 +1,8 @@
 #pragma once
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <string>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 param (
     [string]$config = "Release"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 cmake_args="-DCMAKE_INSTALL_PREFIX:PATH=$PWD/instdir"
 run_clang_tidy=""

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 # Baseline: see .github/workflows/tests.yml.
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 rm -rf workdir
 mkdir workdir

--- a/scripts/extern.py
+++ b/scripts/extern.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 #
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 #
 # Script that checks if newer versions of externals are available.
 #

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 #git pull -r
 scripts/build.sh --debug --werror "$@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 if (WIN32)
     set(CRYPTO cng)

--- a/src/crypto-cng.cxx
+++ b/src/crypto-cng.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <odfsig/crypto.hxx>

--- a/src/crypto-nss.cxx
+++ b/src/crypto-nss.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <odfsig/crypto.hxx>
@@ -132,7 +132,8 @@ bool NssCrypto::initializeKeysManager(xmlSecKeysMngr* keysManager,
     }
 
     return std::all_of(trustedDers.begin(), trustedDers.end(),
-                       [keysManager](const std::string& trustedDer) {
+                       [keysManager](const std::string& trustedDer)
+                       {
                            return xmlSecNssAppKeysMngrCertLoad(
                                       keysManager, trustedDer.c_str(),
                                       xmlSecKeyDataFormatDer,

--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <odfsig/lib.hxx>

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <cstdlib>

--- a/src/string.cxx
+++ b/src/string.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <odfsig/string.hxx>

--- a/src/zip.cxx
+++ b/src/zip.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include "zip.hxx"

--- a/src/zip.hxx
+++ b/src/zip.hxx
@@ -1,8 +1,8 @@
 #pragma once
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <cstddef>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 enable_testing()
 

--- a/tests/keys/generate.sh
+++ b/tests/keys/generate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
-# Copyright 2018 Miklos Vajna. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright 2018 Miklos Vajna
+#
+# SPDX-License-Identifier: MIT
 
 CWD=$PWD
 

--- a/tests/testlib.cxx
+++ b/tests/testlib.cxx
@@ -1,7 +1,7 @@
 /*
- * Copyright 2018 Miklos Vajna. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright 2018 Miklos Vajna
+ *
+ * SPDX-License-Identifier: MIT
  */
 
 #include <cstddef>


### PR DESCRIPTION
Less boilerplate.

Change-Id: Id1dc42b13be57a42caae848408f3c5bb9a8af48e
