### PR TITLE
Fix -Werror,-Wunreachable-code

### DIFF
--- a/include/odfsig/version.hxx.in
+++ b/include/odfsig/version.hxx.in
@@ -2,6 +2,6 @@
 
 #define ODFSIG_VERSION_MAJOR @ODFSIG_VERSION_MAJOR@
 #define ODFSIG_VERSION_MINOR @ODFSIG_VERSION_MINOR@
-#define ODFSIG_VERSION_GIT "@ODFSIG_VERSION_GIT@"
+#cmakedefine ODFSIG_VERSION_GIT "@ODFSIG_VERSION_GIT@"
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -5,7 +5,6 @@
  */
 
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
 #include <memory>
 #include <set>
@@ -218,10 +217,9 @@ int main(const std::vector<const char*>& args, std::ostream& ostream)
     {
         ostream << "odfsig version " << ODFSIG_VERSION_MAJOR << "."
                 << ODFSIG_VERSION_MINOR;
-        if (std::strlen(ODFSIG_VERSION_GIT) > 0)
-        {
-            ostream << "-g" ODFSIG_VERSION_GIT;
-        }
+#ifdef ODFSIG_VERSION_GIT
+        ostream << "-g" ODFSIG_VERSION_GIT;
+#endif
         ostream << std::endl;
         return 0;
     }


### PR DESCRIPTION
When git is not installed. Turn the define that may be empty into either
an undef or a define with a non-empty value.
