### PR TITLE
Fix -Werror,-Wunsafe-buffer-usage

### DIFF
--- a/src/lib.cxx
+++ b/src/lib.cxx
@@ -910,8 +910,8 @@ bool ZipVerifier::parseSignatures()
     while ((readSize = _zipFile->read(readBuffer.data(), readBuffer.size())) >
            0)
     {
-        _signaturesBytes.insert(_signaturesBytes.end(), readBuffer.data(),
-                                readBuffer.data() + readSize);
+        _signaturesBytes.insert(_signaturesBytes.end(), readBuffer.begin(),
+                                readBuffer.begin() + readSize);
     }
     if (readSize == -1)
     {


### PR DESCRIPTION
See <https://clang.llvm.org/docs/SafeBuffers.html>, most of the finds
are just noise, since we interact with libxmlsec, and that's inherently
unsafe. But one usage can be fixed, do it.
